### PR TITLE
Trains API review

### DIFF
--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/cloud/api/TrackForSegment.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/cloud/api/TrackForSegment.java
@@ -3,7 +3,7 @@ package osgi.enroute.trains.cloud.api;
 /**
  * The public Track interface for a Track Controller
  */
-public interface TrackForController extends TrackInfo {
+public interface TrackForSegment extends TrackInfo {
 
 	/**
 	 * Send when a train has been identified at a locator segment

--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/RFIDSegmentController.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/RFIDSegmentController.java
@@ -8,8 +8,13 @@ import org.osgi.util.promise.Promise;
 public interface RFIDSegmentController extends SegmentController {
 
 	/**
+	 * Return the last seen RFID
+	 */
+	String lastRFID();
+	
+	/**
 	 * Read an RFID. Resolves the promise when a new RFID is read.
 	 * @return
 	 */
-	Promise<String> lastRFID();
+	Promise<String> nextRFID();
 }

--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/RFIDSegmentController.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/RFIDSegmentController.java
@@ -1,0 +1,15 @@
+package osgi.enroute.trains.controller.api;
+
+import org.osgi.util.promise.Promise;
+
+/**
+ * This controller controls a LOCATOR Segment
+ */
+public interface RFIDSegmentController extends SegmentController {
+
+	/**
+	 * Read an RFID. Resolves the promise when a new RFID is read.
+	 * @return
+	 */
+	Promise<String> lastRFID();
+}

--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SegmentController.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SegmentController.java
@@ -1,12 +1,8 @@
 package osgi.enroute.trains.controller.api;
 
-import org.osgi.util.promise.Promise;
-
-import osgi.enroute.trains.cloud.api.Color;
 
 /**
- * A controller controls a signal, a switch and an RFID reader. This API provides
- * access to the underlying information
+ * A controller controls a signal, a switch and an RFID reader.
  */
 public interface SegmentController {
 	
@@ -15,24 +11,4 @@ public interface SegmentController {
 	 */
 	String CONTROLLER_ID = "controller.id";
 
-	/**
-	 * Set the signal to the given color
-	 * @param color
-	 */
-	void signal(Color color);
-
-	/**
-	 * Set the switch to normal or the alternative
-	 * @param alternative
-	 */
-	void swtch(boolean alternative);
-	
-	boolean getSwitch();
-	
-
-	/**
-	 * Read an RFID. Resolves the promise when a new RFID is read.
-	 * @return
-	 */
-	Promise<String> lastRFID();
 }

--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SegmentController.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SegmentController.java
@@ -5,10 +5,10 @@ import org.osgi.util.promise.Promise;
 import osgi.enroute.trains.cloud.api.Color;
 
 /**
- * A controller conrols a signal, a switch and an RFID reader. This API provides
+ * A controller controls a signal, a switch and an RFID reader. This API provides
  * access to the underlying information
  */
-public interface Controller {
+public interface SegmentController {
 	
 	/**
 	 * Service property for identifying this controller

--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SignalSegmentController.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SignalSegmentController.java
@@ -1,0 +1,16 @@
+package osgi.enroute.trains.controller.api;
+
+import osgi.enroute.trains.cloud.api.Color;
+
+/**
+ * This controller controls a SIGNAL Segment
+ */
+public interface SignalSegmentController extends SegmentController {
+
+	/**
+	 * Set the signal to the given color
+	 * @param color
+	 */
+	void signal(Color color);
+
+}

--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SignalSegmentController.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SignalSegmentController.java
@@ -13,4 +13,5 @@ public interface SignalSegmentController extends SegmentController {
 	 */
 	void signal(Color color);
 
+	Color getSignal();
 }

--- a/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SwitchSegmentController.java
+++ b/osgi.enroute.trains.api/src/osgi/enroute/trains/controller/api/SwitchSegmentController.java
@@ -1,0 +1,16 @@
+package osgi.enroute.trains.controller.api;
+
+
+/**
+ * This controller controls a SWITCH Segment
+ */
+public interface SwitchSegmentController extends SegmentController {
+
+	/**
+	 * Set the switch to normal or the alternative
+	 * @param alternative
+	 */
+	void swtch(boolean alternative);
+	
+	boolean getSwitch();
+}


### PR DESCRIPTION
I have gone through the API. I would change the `Controller` to `SegmentController`, in order not to confuse with `TrainController`. Likewise I would rename `TrackForController` to `TrackForSegment`.  

I am also not 100% convinced with the `Segment` `Type` that can be SWITCH, SIGNAL, or LOCATOR, and have only one `SegmentController` interface. In this case the `Segment` `Type` will determine which methods of the `SegmentController` actually make sense. Shouldn't we rather use 3 separate interfaces then, e.g.

```
public interface SignalSegmentController extends SegmentController {
  void signal(Color color);
}  
```

```
public interface SwitchSegmentController extends SegmentController {
  void swtch(boolean value);
  boolean getSwitch();
}
```

and 

```
public interface RFIDSegmentController extends SegmentController {
  Promise<String> lastRFID();
}
```

This way the type of the controller automatically determines the segment type and automatically restricts you to the applicable methods? We still keep an (empty) `SegmentController` interface to extend from in case you want to track all `SegmentController`s?
